### PR TITLE
RAIN-289 added check of os to fix newline linux

### DIFF
--- a/openbanking/deploy/setup-ce.sh
+++ b/openbanking/deploy/setup-ce.sh
@@ -2,10 +2,16 @@
 
 source deploy/ce_admin.env
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        OPT="-w 0"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+        OPT=""
+fi
+
 function get_token {
-  ACCESS_TOKEN=$(curl -k  --request POST \
+  ACCESS_TOKEN=$(curl -k --http1.1 --request POST \
   --url https://$DOMAIN/$TENANT_ID/admin/oauth2/token \
-  --header "Authorization: Basic `echo -n $CLIENT_ID:$CLIENT_SECRET | base64`" \
+  --header "Authorization: Basic $(echo -n $CLIENT_ID:$CLIENT_SECRET | base64 $OPT)" \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data grant_type=client_credentials | jq -r '.access_token')
 }


### PR DESCRIPTION
RAIN-289 [setup script not working on linux](https://cloudentity.atlassian.net/browse/RAIN-298)

This PR addresses a failure of the setup script to obtain an access token which results in null values written to .env. 